### PR TITLE
Bugfixes to Pytorch implementation

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -456,6 +456,7 @@ op_handler['Sigmoid'] = nonlinear_1d
 op_handler["Tanh"] = nonlinear_1d
 op_handler["Softplus"] = nonlinear_1d
 op_handler['Softmax'] = nonlinear_1d
+op_handler['Exp'] = nonlinear_1d
 
 op_handler['MaxPool1d'] = maxpool
 op_handler['MaxPool2d'] = maxpool


### PR DESCRIPTION
The implementation for `PyTorchDeepExplainer` no longer works. I updated the code to reflect what is in the [main shap repository](https://github.com/slundberg/shap/blob/master/shap/explainers/_deep/deep_pytorch.py) to bring functionality up to speed since the repo was forked.
* Fixed the order that forward and backward hooks are registered.
* Updated calculation of the gradient with `torch.autograd.grad` to account for proper indexing.
* No longer delete attributes x and y from modules that hook to `maxpool` or `nonlinear_1d`.
* Fix calculation of gradient input size for `MaxPool1d`.

I also added support for the Exp function. Pytorch does not contain a Module for this function, but I use a custom implementation of this Module in my models.